### PR TITLE
chore: update CI workflow to use forge instead of hardhat

### DIFF
--- a/.github/workflows/contract-test.yml
+++ b/.github/workflows/contract-test.yml
@@ -3,17 +3,11 @@ on:
   push:
     paths:
       - "contracts/**"
-      - ".github/workflows/contract-test.yaml"
+      - ".github/workflows/contract-test.yml"
   pull_request:
     paths:
       - "contracts/**"
-      - ".github/workflows/contract-test.yaml"
-
-env:
-  ENDPOINT_URL: ${{ vars.ENDPOINT_URL }}
-  NFT_OWNER: ${{ vars.NFT_OWNER }}
-  PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-  ALCHEMY_KEY: ${{ secrets.ALCHEMY_KEY }}
+      - ".github/workflows/contract-test.yml"
 
 permissions:
   contents: read
@@ -24,32 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: foundry-rs/foundry-toolchain@v1
-      - uses: oven-sh/setup-bun@v2
 
-      - name: "Install the Node.js dependencies"
-        working-directory: ./contracts
-        run: bun install
-      
-      - name: Set Hardhat Variables
-        working-directory: ./contracts
-        run: |
-          npx hardhat vars set ENDPOINT_URL "${{ vars.ENDPOINT_URL }}"
-          npx hardhat vars set PRIVATE_KEY "${{ secrets.PRIVATE_KEY }}"
-          npx hardhat vars set ALCHEMY_KEY "${{ secrets.ALCHEMY_KEY }}"
-      
       - name: "Build the contracts"
         working-directory: ./contracts
-        run: npx hardhat compile --force
-
-      # - name: "Build the contracts and print their size"
-      #   working-directory: ./contracts
-      #   run: forge build --sizes
-
-      # - name: "Add build summary"
-      #   working-directory: ./contracts
-      #   run: |
-      #     echo "## Build result" >> $GITHUB_STEP_SUMMARY
-      #     echo "✅ Passed" >> $GITHUB_STEP_SUMMARY
+        run: forge build
 
   test:
     needs: ["build"]
@@ -57,19 +29,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: foundry-rs/foundry-toolchain@v1
-      - uses: oven-sh/setup-bun@v2
-      - uses: actions/setup-node@v4
-
-      - name: Install Dependencies
-        working-directory: ./contracts
-        run: bun install
-
-      - name: Set Hardhat Variables
-        working-directory: ./contracts
-        run: |
-          npx hardhat vars set ENDPOINT_URL "${{ vars.ENDPOINT_URL }}"
-          npx hardhat vars set PRIVATE_KEY "${{ secrets.PRIVATE_KEY }}"
-          npx hardhat vars set ALCHEMY_KEY "${{ secrets.ALCHEMY_KEY }}"
 
       - name: "Show the Foundry config"
         working-directory: ./contracts
@@ -77,4 +36,4 @@ jobs:
 
       - name: Run Tests
         working-directory: ./contracts
-        run: npx hardhat test --network hardhat
+        run: forge test -vvv

--- a/.github/workflows/contract-test.yml
+++ b/.github/workflows/contract-test.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: foundry-rs/foundry-toolchain@v1
+      - uses: oven-sh/setup-bun@v2
+
+      - name: "Install dependencies"
+        working-directory: ./contracts
+        run: bun install
 
       - name: "Build the contracts"
         working-directory: ./contracts
@@ -29,6 +34,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: foundry-rs/foundry-toolchain@v1
+      - uses: oven-sh/setup-bun@v2
+
+      - name: "Install dependencies"
+        working-directory: ./contracts
+        run: bun install
 
       - name: "Show the Foundry config"
         working-directory: ./contracts

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,6 +1,5 @@
 # Settlus Contracts
-
-Smart contracts for [Settlus](https://settlus.org).
+Smart contracts for [Settlus](https://settlus.org). Mostly migrating [settlement](https://github.com/settlus/chain/tree/main/x/settlement) module from Settlus chain.
 
 ## Getting Started
 


### PR DESCRIPTION
   Remove hardhat-related dependencies and environment variables from
   the contract-test workflow, replacing with pure forge commands.

   🤖 Generated with [Claude Code](https://claude.com/claude-code)

   Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>